### PR TITLE
chore: promote aspnet-app-001 to version 0.0.9

### DIFF
--- a/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-aspnet-app-001-deploy.yaml
+++ b/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-aspnet-app-001-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: aspnet-app-001-aspnet-app-001
   labels:
     draft: draft-app
-    chart: "aspnet-app-001-0.0.8"
+    chart: "aspnet-app-001-0.0.9"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'aspnet-app-001'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: aspnet-app-001-aspnet-app-001
       containers:
       - name: aspnet-app-001
-        image: "10.102.238.180/mysoftdevops/aspnet-app-001:0.0.8"
+        image: "10.102.238.180/mysoftdevops/aspnet-app-001:0.0.9"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.8
+          value: 0.0.9
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-svc.yaml
+++ b/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: aspnet-app-001
   labels:
-    chart: "aspnet-app-001-0.0.8"
+    chart: "aspnet-app-001-0.0.9"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'aspnet-app-001'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 8c9a66051bfb62d554d483693a0c083c845d1fb7a6a4cfad4e244df134eb7bdc
-        checksum/secret: e7fe54296d993a6e97dcc537d493b3ed2799af30395c765499c663c2559e4a48
+        checksum/secret: 52974b78b61e9e076fcb4483eeb183eee08cf8f638b61f73c392816a7c25fdd1
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts/
 releases:
 - chart: dev/aspnet-app-001
-  version: 0.0.8
+  version: 0.0.9
   name: aspnet-app-001
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# aspnet-app-001

## Changes in version 0.0.9

### Chores

* release 0.0.9 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Update README.md (mysoftdevops)
