### PR TITLE
chore: promote aspnet-app-001 to version 0.0.11

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -3,5 +3,6 @@ helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
 - path: helmfiles/jx-staging/helmfile.yaml
+- path: helmfiles/jx-production/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-production
+repositories:
+- name: dev
+  url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts/
+releases:
+- chart: dev/aspnet-app-001
+  version: 0.0.11
+  name: aspnet-app-001
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# aspnet-app-001

## Changes in version 0.0.11

### Chores

* release 0.0.11 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Update README.md (mysoftdevops)
* 换新 (huyc04)
