### PR TITLE
chore: promote aspnet-app-001 to version 0.0.14

### DIFF
--- a/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-aspnet-app-001-deploy.yaml
+++ b/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-aspnet-app-001-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: aspnet-app-001-aspnet-app-001
   labels:
     draft: draft-app
-    chart: "aspnet-app-001-0.0.13"
+    chart: "aspnet-app-001-0.0.14"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'aspnet-app-001'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: aspnet-app-001-aspnet-app-001
       containers:
       - name: aspnet-app-001
-        image: "10.102.238.180/mysoftdevops/aspnet-app-001:0.0.13"
+        image: "10.102.238.180/mysoftdevops/aspnet-app-001:0.0.14"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.13
+          value: 0.0.14
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-svc.yaml
+++ b/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: aspnet-app-001
   labels:
-    chart: "aspnet-app-001-0.0.13"
+    chart: "aspnet-app-001-0.0.14"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'aspnet-app-001'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 8c9a66051bfb62d554d483693a0c083c845d1fb7a6a4cfad4e244df134eb7bdc
-        checksum/secret: edadf07e08e5b1d5347d57da21acc7dc6793051b03c8b3f79ff6b4cc80f60ab4
+        checksum/secret: 06eee4e598dbbeffb7930e363ade0b47634b1eada5a3a872cfeca531cbe1745d
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts/
 releases:
 - chart: dev/aspnet-app-001
-  version: 0.0.13
+  version: 0.0.14
   name: aspnet-app-001
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# aspnet-app-001

## Changes in version 0.0.14

### Chores

* release 0.0.14 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* 修改docker2 (huyc04)
