### PR TITLE
chore: promote aspnet-app-001 to version 0.0.14

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts/
 releases:
 - chart: dev/aspnet-app-001
-  version: 0.0.11
+  version: 0.0.14
   name: aspnet-app-001
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# aspnet-app-001

## Changes in version 0.0.14

### Chores

* release 0.0.14 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* 修改docker2 (huyc04)
