### PR TITLE
chore: promote aspnet-app-001 to version 0.0.15

### DIFF
--- a/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-aspnet-app-001-deploy.yaml
+++ b/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-aspnet-app-001-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: aspnet-app-001/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aspnet-app-001-aspnet-app-001
+  labels:
+    draft: draft-app
+    chart: "aspnet-app-001-0.0.15"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'aspnet-app-001'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: aspnet-app-001-aspnet-app-001
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: aspnet-app-001-aspnet-app-001
+    spec:
+      serviceAccountName: aspnet-app-001-aspnet-app-001
+      containers:
+      - name: aspnet-app-001
+        image: "10.102.238.180/mysoftdevops/aspnet-app-001:0.0.15"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VERSION
+          value: 0.0.15
+        envFrom: null
+        ports:
+        - name: http
+          containerPort: 80
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 400m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+      - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-aspnet-app-001-sa.yaml
+++ b/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-aspnet-app-001-sa.yaml
@@ -1,0 +1,10 @@
+# Source: aspnet-app-001/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aspnet-app-001-aspnet-app-001
+  annotations:
+    meta.helm.sh/release-name: 'aspnet-app-001'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-ingress.yaml
+++ b/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: aspnet-app-001/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'aspnet-app-001'
+  name: aspnet-app-001
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: aspnet-app-001
+            port:
+              number: 80
+    host: aspnet-app-001-jx-staging.192.168.49.2.nip.io

--- a/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-svc.yaml
+++ b/config-root/namespaces/jx-staging/aspnet-app-001/aspnet-app-001-svc.yaml
@@ -1,0 +1,20 @@
+# Source: aspnet-app-001/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: aspnet-app-001
+  labels:
+    chart: "aspnet-app-001-0.0.15"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'aspnet-app-001'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: aspnet-app-001-aspnet-app-001

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 8c9a66051bfb62d554d483693a0c083c845d1fb7a6a4cfad4e244df134eb7bdc
-        checksum/secret: 8fc50a1917e1a048ef25ebd389d5a6bdba0164f5b0d50bf76c1a153a75b150e6
+        checksum/secret: 4d8127176eb12f85821868d45dcbb31103ecab61c69f65223f37180bbff9b92e
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/aspnet-app-001
   version: 0.0.15
   name: aspnet-app-001
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,5 +7,9 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts/
+releases:
+- chart: dev/aspnet-app-001
+  version: 0.0.15
+  name: aspnet-app-001
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# aspnet-app-001

## Changes in version 0.0.15

### Chores

* release 0.0.15 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Update README.md (mysoftdevops)
