### PR TITLE
chore: promote aspnet-app-001 to version 0.0.18

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -7,5 +7,9 @@ namespace: jx-production
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts/
+releases:
+- chart: dev/aspnet-app-001
+  version: 0.0.18
+  name: aspnet-app-001
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# aspnet-app-001

## Changes in version 0.0.18

### Chores

* release 0.0.18 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* 更新应用 (huyc04)
