### PR TITLE
chore: promote aspnet-app-001 to version 0.0.20

### DIFF
--- a/config-root/namespaces/jx-production/aspnet-app-001/aspnet-app-001-aspnet-app-001-deploy.yaml
+++ b/config-root/namespaces/jx-production/aspnet-app-001/aspnet-app-001-aspnet-app-001-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: aspnet-app-001/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aspnet-app-001-aspnet-app-001
+  labels:
+    draft: draft-app
+    chart: "aspnet-app-001-0.0.20"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'aspnet-app-001'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: aspnet-app-001-aspnet-app-001
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: aspnet-app-001-aspnet-app-001
+    spec:
+      serviceAccountName: aspnet-app-001-aspnet-app-001
+      containers:
+      - name: aspnet-app-001
+        image: "10.102.238.180/mysoftdevops/aspnet-app-001:0.0.20"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VERSION
+          value: 0.0.20
+        envFrom: null
+        ports:
+        - name: http
+          containerPort: 80
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 400m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+      - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-production/aspnet-app-001/aspnet-app-001-aspnet-app-001-sa.yaml
+++ b/config-root/namespaces/jx-production/aspnet-app-001/aspnet-app-001-aspnet-app-001-sa.yaml
@@ -1,0 +1,10 @@
+# Source: aspnet-app-001/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aspnet-app-001-aspnet-app-001
+  annotations:
+    meta.helm.sh/release-name: 'aspnet-app-001'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/aspnet-app-001/aspnet-app-001-ingress.yaml
+++ b/config-root/namespaces/jx-production/aspnet-app-001/aspnet-app-001-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: aspnet-app-001/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'aspnet-app-001'
+  name: aspnet-app-001
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: aspnet-app-001
+            port:
+              number: 80
+    host: aspnet-app-001-jx-production.192.168.49.2.nip.io

--- a/config-root/namespaces/jx-production/aspnet-app-001/aspnet-app-001-svc.yaml
+++ b/config-root/namespaces/jx-production/aspnet-app-001/aspnet-app-001-svc.yaml
@@ -1,0 +1,20 @@
+# Source: aspnet-app-001/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: aspnet-app-001
+  labels:
+    chart: "aspnet-app-001-0.0.20"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'aspnet-app-001'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: aspnet-app-001-aspnet-app-001

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 8c9a66051bfb62d554d483693a0c083c845d1fb7a6a4cfad4e244df134eb7bdc
-        checksum/secret: 966618e9a3c43c78210eb965b1b2dfadc4822b7927880085639479e0ac4158ff
+        checksum/secret: 2459d137ec125b05a6cfede2cc139556405875920d86eddf012432aaaea4f5a0
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/aspnet-app-001
   version: 0.0.20
   name: aspnet-app-001
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# aspnet-app-001

## Changes in version 0.0.20

### Chores

* release 0.0.20 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* addjust (huyc04)
